### PR TITLE
Feature/rank-field-ranges

### DIFF
--- a/gridformat/vtk/common.hpp
+++ b/gridformat/vtk/common.hpp
@@ -221,7 +221,12 @@ auto make_cell_types_field(const Grid& grid) {
     });
 }
 
-inline constexpr std::array active_array_attribute = {"Scalars", "Vectors", "Tensors"};
+inline auto active_array_attribute_for_rank(unsigned int rank) {
+    if (rank > 2)
+        throw ValueError("Rank must be <= 2");
+    static constexpr std::array attributes{"Scalars", "Vectors", "Tensors"};
+    return attributes[rank];
+}
 
 namespace CommonDetail {
 

--- a/gridformat/vtk/pvti_writer.hpp
+++ b/gridformat/vtk/pvti_writer.hpp
@@ -145,6 +145,7 @@ class PVTIWriter : public VTK::XMLWriterBase<Grid, PVTIWriter<Grid, Communicator
             piece.set_attribute("Source", PVTK::piece_basefilename(filename_with_ext, rank) + ".vti");
         });
 
+        this->_set_default_active_fields(pvtk_xml.get_child("PImageData"));
         write_xml_with_version_header(pvtk_xml, file_stream, Indentation{{.width = 2}});
     }
 };

--- a/gridformat/vtk/pvtp_writer.hpp
+++ b/gridformat/vtk/pvtp_writer.hpp
@@ -103,6 +103,7 @@ class PVTPWriter : public VTK::XMLWriterBase<Grid, PVTPWriter<Grid, Communicator
             );
         });
 
+        this->_set_default_active_fields(pvtk_xml.get_child("PPolyData"));
         write_xml_with_version_header(pvtk_xml, file_stream, Indentation{{.width = 2}});
     }
 };

--- a/gridformat/vtk/pvtr_writer.hpp
+++ b/gridformat/vtk/pvtr_writer.hpp
@@ -161,6 +161,7 @@ class PVTRWriter : public VTK::XMLWriterBase<Grid, PVTRWriter<Grid, Communicator
             piece.set_attribute("Source", PVTK::piece_basefilename(filename_with_ext, rank) + ".vtr");
         });
 
+        this->_set_default_active_fields(pvtk_xml.get_child("PRectilinearGrid"));
         write_xml_with_version_header(pvtk_xml, file_stream, Indentation{{.width = 2}});
     }
 };

--- a/gridformat/vtk/pvts_writer.hpp
+++ b/gridformat/vtk/pvts_writer.hpp
@@ -186,6 +186,7 @@ class PVTSWriter : public VTK::XMLWriterBase<Grid, PVTSWriter<Grid, Communicator
             piece.set_attribute("Source", PVTK::piece_basefilename(filename_with_ext, rank) + ".vts");
         });
 
+        this->_set_default_active_fields(pvtk_xml.get_child("PStructuredGrid"));
         write_xml_with_version_header(pvtk_xml, file_stream, Indentation{{.width = 2}});
     }
 };

--- a/gridformat/vtk/pvtu_writer.hpp
+++ b/gridformat/vtk/pvtu_writer.hpp
@@ -103,6 +103,7 @@ class PVTUWriter : public VTK::XMLWriterBase<Grid, PVTUWriter<Grid, Communicator
             );
         });
 
+        this->_set_default_active_fields(pvtk_xml.get_child("PUnstructuredGrid"));
         write_xml_with_version_header(pvtk_xml, file_stream, Indentation{{.width = 2}});
     }
 };

--- a/gridformat/vtk/vti_writer.hpp
+++ b/gridformat/vtk/vti_writer.hpp
@@ -79,15 +79,6 @@ class VTIWriter : public VTK::XMLWriterBase<Grid, VTIWriter<Grid>> {
             this->_set_data_array(context, "Piece.CellData", name, vtk_cell_fields.get(name));
         });
 
-        // set default active arrays (scalars, vectors, tensors)
-        for (std::size_t i = 0; i <= 2; ++i)
-        {
-            for (const auto& [n, _] : cell_fields_of_rank(i, *this) | std::views::take(1))
-                this->_set_attribute(context, "Piece.CellData", VTK::active_array_attribute[i], n);
-            for (const auto& [n, _] : point_fields_of_rank(i, *this) | std::views::take(1))
-                this->_set_attribute(context, "Piece.PointData", VTK::active_array_attribute[i], n);
-        }
-
         this->_write_xml(std::move(context), s);
     }
 

--- a/gridformat/vtk/vti_writer.hpp
+++ b/gridformat/vtk/vti_writer.hpp
@@ -80,13 +80,12 @@ class VTIWriter : public VTK::XMLWriterBase<Grid, VTIWriter<Grid>> {
         });
 
         // set default active arrays (scalars, vectors, tensors)
-        for (std::size_t i = 1; i <= 3; ++i)
+        for (std::size_t i = 0; i <= 2; ++i)
         {
-            if (const auto cell_default = this->first_cell_field(i); !cell_default.empty())
-                this->_set_attribute(context, "Piece.CellData", VTK::active_array_attribute[i-1], cell_default);
-
-            if (const auto point_default = this->first_point_field(i); !point_default.empty())
-                this->_set_attribute(context, "Piece.PointData", VTK::active_array_attribute[i-1], point_default);
+            for (const auto& [n, _] : cell_fields_of_rank(i, *this) | std::views::take(1))
+                this->_set_attribute(context, "Piece.CellData", VTK::active_array_attribute[i], n);
+            for (const auto& [n, _] : point_fields_of_rank(i, *this) | std::views::take(1))
+                this->_set_attribute(context, "Piece.PointData", VTK::active_array_attribute[i], n);
         }
 
         this->_write_xml(std::move(context), s);

--- a/gridformat/vtk/vtp_writer.hpp
+++ b/gridformat/vtk/vtp_writer.hpp
@@ -114,13 +114,12 @@ class VTPWriter : public VTK::XMLWriterBase<Grid, VTPWriter<Grid>> {
         });
 
         // set default active arrays (scalars, vectors, tensors)
-        for (std::size_t i = 1; i <= 3; ++i)
+        for (std::size_t i = 0; i <= 2; ++i)
         {
-            if (const auto cell_default = this->first_cell_field(i); !cell_default.empty())
-                this->_set_attribute(context, "Piece.CellData", VTK::active_array_attribute[i-1], cell_default);
-
-            if (const auto point_default = this->first_point_field(i); !point_default.empty())
-                this->_set_attribute(context, "Piece.PointData", VTK::active_array_attribute[i-1], point_default);
+            for (const auto& [n, _] : cell_fields_of_rank(i, *this) | std::views::take(1))
+                this->_set_attribute(context, "Piece.CellData", VTK::active_array_attribute[i], n);
+            for (const auto& [n, _] : point_fields_of_rank(i, *this) | std::views::take(1))
+                this->_set_attribute(context, "Piece.PointData", VTK::active_array_attribute[i], n);
         }
 
         const FieldPtr coords_field = std::visit([&] <typename T> (const Precision<T>&) {

--- a/gridformat/vtk/vtp_writer.hpp
+++ b/gridformat/vtk/vtp_writer.hpp
@@ -113,15 +113,6 @@ class VTPWriter : public VTK::XMLWriterBase<Grid, VTPWriter<Grid>> {
             this->_set_data_array(context, "Piece.CellData", name, vtk_cell_fields.get(name));
         });
 
-        // set default active arrays (scalars, vectors, tensors)
-        for (std::size_t i = 0; i <= 2; ++i)
-        {
-            for (const auto& [n, _] : cell_fields_of_rank(i, *this) | std::views::take(1))
-                this->_set_attribute(context, "Piece.CellData", VTK::active_array_attribute[i], n);
-            for (const auto& [n, _] : point_fields_of_rank(i, *this) | std::views::take(1))
-                this->_set_attribute(context, "Piece.PointData", VTK::active_array_attribute[i], n);
-        }
-
         const FieldPtr coords_field = std::visit([&] <typename T> (const Precision<T>&) {
             return VTK::make_coordinates_field<T>(this->grid(), false);
         }, this->_xml_settings.coordinate_precision);

--- a/gridformat/vtk/vtr_writer.hpp
+++ b/gridformat/vtk/vtr_writer.hpp
@@ -83,15 +83,6 @@ class VTRWriter : public VTK::XMLWriterBase<Grid, VTRWriter<Grid>> {
             this->_set_data_array(context, "Piece.CellData", name, vtk_cell_fields.get(name));
         });
 
-        // set default active arrays (scalars, vectors, tensors)
-        for (std::size_t i = 0; i <= 2; ++i)
-        {
-            for (const auto& [n, _] : cell_fields_of_rank(i, *this) | std::views::take(1))
-                this->_set_attribute(context, "Piece.CellData", VTK::active_array_attribute[i], n);
-            for (const auto& [n, _] : point_fields_of_rank(i, *this) | std::views::take(1))
-                this->_set_attribute(context, "Piece.PointData", VTK::active_array_attribute[i], n);
-        }
-
         const auto coord_fields = _make_ordinate_fields();
         for (unsigned dir = 0; dir < space_dim; ++dir)
             this->_set_data_array(context, "Piece.Coordinates", "X_" + std::to_string(dir), *coord_fields[dir]);

--- a/gridformat/vtk/vtr_writer.hpp
+++ b/gridformat/vtk/vtr_writer.hpp
@@ -84,13 +84,12 @@ class VTRWriter : public VTK::XMLWriterBase<Grid, VTRWriter<Grid>> {
         });
 
         // set default active arrays (scalars, vectors, tensors)
-        for (std::size_t i = 1; i <= 3; ++i)
+        for (std::size_t i = 0; i <= 2; ++i)
         {
-            if (const auto cell_default = this->first_cell_field(i); !cell_default.empty())
-                this->_set_attribute(context, "Piece.CellData", VTK::active_array_attribute[i-1], cell_default);
-
-            if (const auto point_default = this->first_point_field(i); !point_default.empty())
-                this->_set_attribute(context, "Piece.PointData", VTK::active_array_attribute[i-1], point_default);
+            for (const auto& [n, _] : cell_fields_of_rank(i, *this) | std::views::take(1))
+                this->_set_attribute(context, "Piece.CellData", VTK::active_array_attribute[i], n);
+            for (const auto& [n, _] : point_fields_of_rank(i, *this) | std::views::take(1))
+                this->_set_attribute(context, "Piece.PointData", VTK::active_array_attribute[i], n);
         }
 
         const auto coord_fields = _make_ordinate_fields();

--- a/gridformat/vtk/vts_writer.hpp
+++ b/gridformat/vtk/vts_writer.hpp
@@ -83,13 +83,12 @@ class VTSWriter : public VTK::XMLWriterBase<Grid, VTSWriter<Grid>> {
         });
 
         // set default active arrays (scalars, vectors, tensors)
-        for (std::size_t i = 1; i <= 3; ++i)
+        for (std::size_t i = 0; i <= 2; ++i)
         {
-            if (const auto cell_default = this->first_cell_field(i); !cell_default.empty())
-                this->_set_attribute(context, "Piece.CellData", VTK::active_array_attribute[i-1], cell_default);
-
-            if (const auto point_default = this->first_point_field(i); !point_default.empty())
-                this->_set_attribute(context, "Piece.PointData", VTK::active_array_attribute[i-1], point_default);
+            for (const auto& [n, _] : cell_fields_of_rank(i, *this) | std::views::take(1))
+                this->_set_attribute(context, "Piece.CellData", VTK::active_array_attribute[i], n);
+            for (const auto& [n, _] : point_fields_of_rank(i, *this) | std::views::take(1))
+                this->_set_attribute(context, "Piece.PointData", VTK::active_array_attribute[i], n);
         }
 
         const FieldPtr coords_field = std::visit([&] <typename T> (const Precision<T>&) {

--- a/gridformat/vtk/vts_writer.hpp
+++ b/gridformat/vtk/vts_writer.hpp
@@ -82,15 +82,6 @@ class VTSWriter : public VTK::XMLWriterBase<Grid, VTSWriter<Grid>> {
             this->_set_data_array(context, "Piece.CellData", name, vtk_cell_fields.get(name));
         });
 
-        // set default active arrays (scalars, vectors, tensors)
-        for (std::size_t i = 0; i <= 2; ++i)
-        {
-            for (const auto& [n, _] : cell_fields_of_rank(i, *this) | std::views::take(1))
-                this->_set_attribute(context, "Piece.CellData", VTK::active_array_attribute[i], n);
-            for (const auto& [n, _] : point_fields_of_rank(i, *this) | std::views::take(1))
-                this->_set_attribute(context, "Piece.PointData", VTK::active_array_attribute[i], n);
-        }
-
         const FieldPtr coords_field = std::visit([&] <typename T> (const Precision<T>&) {
             return VTK::make_coordinates_field<T>(this->grid(), true);
         }, this->_xml_settings.coordinate_precision);

--- a/gridformat/vtk/vtu_writer.hpp
+++ b/gridformat/vtk/vtu_writer.hpp
@@ -56,15 +56,6 @@ class VTUWriter : public VTK::XMLWriterBase<Grid, VTUWriter<Grid>> {
             this->_set_data_array(context, "Piece.CellData", name, vtk_cell_fields.get(name));
         });
 
-        // set default active arrays (scalars, vectors, tensors)
-        for (std::size_t i = 0; i <= 2; ++i)
-        {
-            for (const auto& [n, _] : cell_fields_of_rank(i, *this) | std::views::take(1))
-                this->_set_attribute(context, "Piece.CellData", VTK::active_array_attribute[i], n);
-            for (const auto& [n, _] : point_fields_of_rank(i, *this) | std::views::take(1))
-                this->_set_attribute(context, "Piece.PointData", VTK::active_array_attribute[i], n);
-        }
-
         const auto point_id_map = make_point_id_map(this->grid());
         const FieldPtr coords_field = std::visit([&] <typename T> (const Precision<T>&) {
             return VTK::make_coordinates_field<T>(this->grid(), false);

--- a/gridformat/vtk/vtu_writer.hpp
+++ b/gridformat/vtk/vtu_writer.hpp
@@ -57,13 +57,12 @@ class VTUWriter : public VTK::XMLWriterBase<Grid, VTUWriter<Grid>> {
         });
 
         // set default active arrays (scalars, vectors, tensors)
-        for (std::size_t i = 1; i <= 3; ++i)
+        for (std::size_t i = 0; i <= 2; ++i)
         {
-            if (const auto cell_default = this->first_cell_field(i); !cell_default.empty())
-                this->_set_attribute(context, "Piece.CellData", VTK::active_array_attribute[i-1], cell_default);
-
-            if (const auto point_default = this->first_point_field(i); !point_default.empty())
-                this->_set_attribute(context, "Piece.PointData", VTK::active_array_attribute[i-1], point_default);
+            for (const auto& [n, _] : cell_fields_of_rank(i, *this) | std::views::take(1))
+                this->_set_attribute(context, "Piece.CellData", VTK::active_array_attribute[i], n);
+            for (const auto& [n, _] : point_fields_of_rank(i, *this) | std::views::take(1))
+                this->_set_attribute(context, "Piece.PointData", VTK::active_array_attribute[i], n);
         }
 
         const auto point_id_map = make_point_id_map(this->grid());

--- a/gridformat/vtk/xml.hpp
+++ b/gridformat/vtk/xml.hpp
@@ -405,12 +405,12 @@ class XMLWriterBase
         if (_has_element(context, "Piece.PointData"))
             for (unsigned int i = 0; i <= 2; ++i)
                 for (const auto& [n, _] : point_fields_of_rank(i, *this) | std::views::take(1))
-                    _set_attribute(context, "Piece.PointData", VTK::active_array_attribute[i], n);
+                    _set_attribute(context, "Piece.PointData", active_array_attribute_for_rank(i), n);
 
         if (_has_element(context, "Piece.CellData"))
             for (unsigned int i = 0; i <= 2; ++i)
                 for (const auto& [n, _] : cell_fields_of_rank(i, *this) | std::views::take(1))
-                    _set_attribute(context, "Piece.CellData", VTK::active_array_attribute[i], n);
+                    _set_attribute(context, "Piece.CellData", active_array_attribute_for_rank(i), n);
 
     }
 };

--- a/test/vtk/test_pvts_writer.cpp
+++ b/test/vtk/test_pvts_writer.cpp
@@ -7,6 +7,12 @@
 
 #include <gridformat/common/logging.hpp>
 #include <gridformat/parallel/communication.hpp>
+
+// In the GitHub action runner we run into a compiler warning when
+// using release flags. Locally, this could not be reproduced. For
+// now, we simply ignore those warnings here.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wrestrict"
 #include <gridformat/vtk/pvts_writer.hpp>
 
 #include "../grid/structured_grid.hpp"
@@ -104,3 +110,5 @@ int main(int argc, char** argv) {
     MPI_Finalize();
     return 0;
 }
+
+#pragma GCC diagnostic pop


### PR DESCRIPTION
- put active field setting in base xml writer
- instead of a public `first_cell_field` function, I propose a range over fields with a specified rank, of which we take the first one for the default active arrays
- I made the `active_array_attribute` a function to avoid the possibility of segfaults when used wrong

TODO:
- [x] support for pvtk

I tried to split it up into separate commits such that we can kick out those we don't want (i.e. in case you have objections)